### PR TITLE
Fix: Use username instead of view name for logout

### DIFF
--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -102,8 +102,8 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
                     if (evt.getSource().equals(logOut)) {
                         // 1. get the state out of the loggedInViewModel. It contains the username.
                         // 2. Execute the logout Controller.
-                        final String name = loggedInViewModel.getViewName();
-                        logoutController.execute(name);
+                        final LoggedInState currentState = loggedInViewModel.getState();
+                        logoutController.execute(currentState.getUsername());
 
                     }
                 }


### PR DESCRIPTION
# Fix: Use username instead of view name for logout

## Description
This PR fixes a bug in the logout functionality where the wrong value was being passed to the logout controller.

## Problem
The logout button was using `loggedInViewModel.getViewName()` which returns the view name string `"logged in"` instead of the actual username of the currently logged-in user.

## Solution
Changed the logout button action listener in `LoggedInView.java` to:
1. Get the current state from the logged-in view model
2. Extract the username from the state
3. Pass the actual username to the logout controller

## Changes Made
- **File**: `src/main/java/view/LoggedInView.java`
- **Lines changed**: ~2 lines in the logout button action listener
- **Before**: `logoutController.execute(loggedInViewModel.getViewName());`
- **After**: 
  ```java
  final LoggedInState currentState = loggedInViewModel.getState();
  logoutController.execute(currentState.getUsername());
  ```